### PR TITLE
Renew SSL certificates every month

### DIFF
--- a/service/apache2/bin/docker-callbacks.sh
+++ b/service/apache2/bin/docker-callbacks.sh
@@ -4,9 +4,9 @@ function CB_rotate_logs { rotateLogs; }
 function CB_certbot {
 
 return   # For now !!!
-    # If the current certificate is older than ~2 months, then create a certbot HTTP-01
+    # If the current certificate is older than ~1 month, then create a certbot HTTP-01
     # challenge response directory, run certbot and clean up
-    OLDCERT=$(find /etc/letsencrypt/live/forum.${DOMAIN}/fullchain.pem -mtime +61)
+    OLDCERT=$(find /etc/letsencrypt/live/forum.${DOMAIN}/fullchain.pem -mtime +31)
     if [ -n "$OLDCERT" ]; then
       (
         msgInfo "$(date -u) Checking / Renewing *.${DOMAIN} certificates"


### PR DESCRIPTION
Getting ahead of the "TLS Certificate Lifetimes Will Officially Reduce to 47 Days" change - while not required until 2029 it looks like LetsEncrypt will be reducing their certificate lifetime sooner than this.

#### References:
- https://www.digicert.com/blog/tls-certificate-lifetimes-will-officially-reduce-to-47-days 
- https://news.ycombinator.com/item?id=43693900