### PR TITLE
Change mysqldump flags

### DIFF
--- a/service/mysql/bin/docker-callbacks.sh
+++ b/service/mysql/bin/docker-callbacks.sh
@@ -7,7 +7,7 @@ function CB_nightly_backup { USR="$1"
     DUMPFILE=/backups/sql-backups/$DATE
     logInfo "$(date -u) + SQL compression completed in $((SECONDS-t)) secs"
     umask 0007
-    mysqldump --opt ipb > $DUMPFILE.sql
+    mysqldump --opt --single-transaction --skip-dump-date ipb > $DUMPFILE.sql
     logInfo "$(date -u) SQL backup completed in $((SECONDS-t)) secs"
     nice xz -T 4 $DUMPFILE.sql
     chown $USR:$USR $DUMPFILE.sql.xz


### PR DESCRIPTION
Two changes:
1. Our tables use the InnoDB storage engine, so we need `--single-transaction` to dump them in a coherent state
2. `--skip-dump-date` is for my backup benefit, as it means there's one fewere difference between backup files, as the date the dump was made doesn't appear in the file's header.

Has not been tested, as my local environment is not using this Docker setup.