### PR TITLE
Dockerize Restic backups

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,6 +126,65 @@ services:
     secrets:
       - redis-pwd
 
+  backup:
+    image: mazzolino/restic
+    hostname: docker
+    restart: unless-stopped
+    environment:
+      RUN_ON_STARTUP: "true"
+      BACKUP_CRON: "0 30 6 * * *"
+      RESTIC_REPOSITORY: ${RESTIC_REPOSITORY}
+      RESTIC_PASSWORD: ${RESTIC_PASSWORD}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # TODO path to SQL database
+      RESTIC_BACKUP_SOURCES: "/var/www/ipb /backups/ipb.sql"
+      RESTIC_BACKUP_ARGS: >-
+        --tag '.restic/backup'
+        --group-by 'host,tags'
+        --exclude "**/*.log"
+        --exclude "*.log"
+        --verbose
+      RESTIC_FORGET_ARGS: >-
+        --keep-last 10
+        --keep-daily 7
+        --keep-weekly 5
+        --keep-monthly 12
+      TZ: Europe/London
+    volumes:
+      - ${IPB_ROOT}:/var/www/ipb:ro
+      - /backups:/backups
+
+  prune:
+    image: mazzolino/restic
+    hostname: docker
+    restart: unless-stopped
+    environment:
+      SKIP_INIT: "true"
+      RUN_ON_STARTUP: "true"
+      PRUNE_CRON: "0 0 4 * * *"
+      RESTIC_REPOSITORY: ${RESTIC_REPOSITORY}
+      RESTIC_PASSWORD: ${RESTIC_PASSWORD}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      TZ: Europe/London
+
+  check:
+    image: mazzolino/restic
+    hostname: docker
+    restart: unless-stopped
+    environment:
+      SKIP_INIT: "true"
+      RUN_ON_STARTUP: "false"
+      CHECK_CRON: "0 15 5 * * *"
+      RESTIC_CHECK_ARGS: >-
+        --read-data-subset=10%
+      RESTIC_REPOSITORY: ${RESTIC_REPOSITORY}
+      RESTIC_PASSWORD: ${RESTIC_PASSWORD}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      TZ: Europe/London
+
 secrets:
   authorized_keys:
     file: .secrets/authorized_keys

--- a/env.default-template
+++ b/env.default-template
@@ -30,6 +30,12 @@ LICENCE_KEY=
 ALPINE_VERSION=
 MYSQL_VERSION=
 PHP_VERSION=
+
+# Backups
+RESTIC_REPOSITORY=
+RESTIC_PASSWORD=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
 #
 ## The .secrets folder contain the following files:
 #   -   mysql-root & redis-pwd; these must match the value of the env variables


### PR DESCRIPTION
As requested in #21 I've Dockerized the backup. I used restic in the end, as it already has a good Docker base image.

This is not properly tested because it's hard to do without pushing to the backup location.

## Before this goes into production
The SQL file that I referenced doesn't exist at that location. We need to sort out where it's going to be, how it's going to get there, and update the definition.